### PR TITLE
Waila Integration Improvements

### DIFF
--- a/src/main/java/ecomod/common/tiles/TileAdvancedFilter.java
+++ b/src/main/java/ecomod/common/tiles/TileAdvancedFilter.java
@@ -97,7 +97,7 @@ public class TileAdvancedFilter extends TileEnergy implements ITickable, buildcr
 					
 					if(energy.extractEnergyNotOfficially(EMConfig.advanced_filter_energy_per_second * EMConfig.adv_filter_delay_secs, false) == EMConfig.advanced_filter_energy_per_second * EMConfig.adv_filter_delay_secs)
 					{
-						EcomodAPI.emitPollution(getWorld(), getChunkCoords(), PollutionSourcesConfig.getSource("advanced_filter_reduction"), false);
+						EcomodAPI.emitPollution(getWorld(), getChunkCoords(), getSource(), false);
 					
 						tank.fillInternal(getProduction(), true);
 					
@@ -147,6 +147,10 @@ public class TileAdvancedFilter extends TileEnergy implements ITickable, buildcr
 		
 		return ret;
 	}
+
+	public PollutionData getSource() {
+		return PollutionSourcesConfig.getSource("advanced_filter_reduction");
+	}
 	
 	public FluidStack getProduction()
 	{
@@ -157,7 +161,7 @@ public class TileAdvancedFilter extends TileEnergy implements ITickable, buildcr
 		
 		FluidStack ret = new FluidStack(EcomodStuff.concentrated_pollution, 0);
 		
-		PollutionData adv_filter_reduction = PollutionSourcesConfig.getSource("advanced_filter_reduction");
+		PollutionData adv_filter_reduction = getSource();
 		
 		for(PollutionType type : PollutionType.values())
 		{

--- a/src/main/java/ecomod/core/stuff/compat/EMWailaHandler.java
+++ b/src/main/java/ecomod/core/stuff/compat/EMWailaHandler.java
@@ -16,6 +16,7 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.translation.I18n;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.List;
 
 public class EMWailaHandler implements IWailaDataProvider
@@ -28,11 +29,11 @@ public class EMWailaHandler implements IWailaDataProvider
 
 		if(tile != null)
 		{
+			boolean isCrouching = accessor.getPlayer().isSneaking();
 			PollutionData data = null;
 			TEPollutionConfig.TEPollution pollution = EcologyMod.instance.tepc.getTEP(tile);
-			if (pollution != null) {
+			if (pollution != null)
 				data = pollution.getEmission();
-			}
 			if(tile instanceof TileEnergy)
 				currentTip.add("Energy: " + TextFormatting.YELLOW + ((TileEnergy)tile).getEnergyStored() + " / " + ((TileEnergy)tile).getMaxEnergyStored() + " RF");
 			if(tile instanceof TileAdvancedFilter)
@@ -44,21 +45,28 @@ public class EMWailaHandler implements IWailaDataProvider
 					data = filter.getSource();
 			}
 			if (data != null) {
+				ArrayList<String> pollutionText = new ArrayList<>();
 				float air = data.getAirPollution(), soil = data.getSoilPollution(), water = data.getWaterPollution();
 				if(air <= -0.1D)
-					currentTip.add(TextFormatting.YELLOW + "" + TextFormatting.ITALIC + "Air Pollution: " + TextFormatting.GREEN + Float.toString(air));
+					pollutionText.add(TextFormatting.YELLOW + "" + TextFormatting.ITALIC + "Air Pollution: " + TextFormatting.GREEN + Float.toString(air));
 				else if(air >= 0.1D)
-					currentTip.add(TextFormatting.YELLOW + "" + TextFormatting.ITALIC + "Air Pollution: " + TextFormatting.RED + '+' + Float.toString(air));
+					pollutionText.add(TextFormatting.YELLOW + "" + TextFormatting.ITALIC + "Air Pollution: " + TextFormatting.RED + '+' + Float.toString(air));
 
 				if(water <= -0.1D)
-					currentTip.add(TextFormatting.AQUA + "" + TextFormatting.ITALIC + "Water Pollution: " + TextFormatting.GREEN + Float.toString(water));
+					pollutionText.add(TextFormatting.AQUA + "" + TextFormatting.ITALIC + "Water Pollution: " + TextFormatting.GREEN + Float.toString(water));
 				else if(water >= 0.1D)
-					currentTip.add(TextFormatting.AQUA + "" + TextFormatting.ITALIC + "Water Pollution: " + TextFormatting.RED + '+' + Float.toString(water));
+					pollutionText.add(TextFormatting.AQUA + "" + TextFormatting.ITALIC + "Water Pollution: " + TextFormatting.RED + '+' + Float.toString(water));
 
 				if(soil <= -0.1D)
-					currentTip.add(TextFormatting.GOLD + "" + TextFormatting.ITALIC + "Soil Pollution: " + TextFormatting.GREEN + Float.toString(soil));
+					pollutionText.add(TextFormatting.GOLD + "" + TextFormatting.ITALIC + "Soil Pollution: " + TextFormatting.GREEN + Float.toString(soil));
 				else if(soil >= 0.1D)
-					currentTip.add(TextFormatting.GOLD + "" + TextFormatting.ITALIC + "Soil Pollution: " + TextFormatting.RED + '+' + Float.toString(soil));
+					pollutionText.add(TextFormatting.GOLD + "" + TextFormatting.ITALIC + "Soil Pollution: " + TextFormatting.RED + '+' + Float.toString(soil));
+				if (!pollutionText.isEmpty()) {
+					if (isCrouching)
+						currentTip.addAll(pollutionText);
+					else
+						currentTip.add("Sneak to view detailed pollution information.");
+				}
 			}
 		}
 

--- a/src/main/java/ecomod/core/stuff/compat/EMWailaHandler.java
+++ b/src/main/java/ecomod/core/stuff/compat/EMWailaHandler.java
@@ -1,11 +1,11 @@
 package ecomod.core.stuff.compat;
 
 import ecomod.api.EcomodStuff;
-import ecomod.common.blocks.BlockAdvancedFilter;
-import ecomod.common.blocks.BlockAnalyzer;
-import ecomod.common.blocks.BlockFilter;
+import ecomod.api.pollution.PollutionData;
+import ecomod.common.pollution.TEPollutionConfig;
 import ecomod.common.tiles.TileAdvancedFilter;
 import ecomod.common.tiles.TileEnergy;
+import ecomod.core.EcologyMod;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 import mcp.mobius.waila.api.IWailaDataProvider;
@@ -15,35 +15,58 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.translation.I18n;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
 public class EMWailaHandler implements IWailaDataProvider
 {
 	@Override
+	@Nonnull
 	public List<String> getWailaBody(ItemStack itemStack, List<String> currentTip, IWailaDataAccessor accessor, IWailaConfigHandler config)
 	{
 		TileEntity tile = accessor.getTileEntity();
-		
+
 		if(tile != null)
 		{
-			if(tile instanceof TileEnergy)
-			{
-				currentTip.add("Energy: "+TextFormatting.YELLOW+((TileEnergy)tile).getEnergyStored() +" / "+((TileEnergy)tile).getMaxEnergyStored()+" RF");
+			PollutionData data = null;
+			TEPollutionConfig.TEPollution pollution = EcologyMod.instance.tepc.getTEP(tile);
+			if (pollution != null) {
+				data = pollution.getEmission();
 			}
+			if(tile instanceof TileEnergy)
+				currentTip.add("Energy: " + TextFormatting.YELLOW + ((TileEnergy)tile).getEnergyStored() + " / " + ((TileEnergy)tile).getMaxEnergyStored() + " RF");
 			if(tile instanceof TileAdvancedFilter)
 			{
-				currentTip.add(I18n.translateToLocal(EcomodStuff.concentrated_pollution.getUnlocalizedName()) + ' ' + ((TileAdvancedFilter)tile).tank.getFluidAmount() + " / " + ((TileAdvancedFilter)tile).tank.getCapacity()+" mb");
-				currentTip.add(((TileAdvancedFilter)tile).was_working ? TextFormatting.GREEN+"Working" : TextFormatting.RED+"Not Working");
+				TileAdvancedFilter filter = (TileAdvancedFilter)tile;
+				currentTip.add(I18n.translateToLocal(EcomodStuff.concentrated_pollution.getUnlocalizedName()) + ": " + filter.tank.getFluidAmount() + " / " + filter.tank.getCapacity() + " mb");
+				currentTip.add(filter.was_working ? TextFormatting.GREEN + "Working" : TextFormatting.RED + "Not Working");
+				if (filter.was_working) //If it is not working do not show it is reducing pollution
+					data = filter.getSource();
+			}
+			if (data != null) {
+				float air = data.getAirPollution(), soil = data.getSoilPollution(), water = data.getWaterPollution();
+				if(air <= -0.1D)
+					currentTip.add(TextFormatting.YELLOW + "" + TextFormatting.ITALIC + "Air Pollution: " + TextFormatting.GREEN + Float.toString(air));
+				else if(air >= 0.1D)
+					currentTip.add(TextFormatting.YELLOW + "" + TextFormatting.ITALIC + "Air Pollution: " + TextFormatting.RED + '+' + Float.toString(air));
+
+				if(water <= -0.1D)
+					currentTip.add(TextFormatting.AQUA + "" + TextFormatting.ITALIC + "Water Pollution: " + TextFormatting.GREEN + Float.toString(water));
+				else if(water >= 0.1D)
+					currentTip.add(TextFormatting.AQUA + "" + TextFormatting.ITALIC + "Water Pollution: " + TextFormatting.RED + '+' + Float.toString(water));
+
+				if(soil <= -0.1D)
+					currentTip.add(TextFormatting.GOLD + "" + TextFormatting.ITALIC + "Soil Pollution: " + TextFormatting.GREEN + Float.toString(soil));
+				else if(soil >= 0.1D)
+					currentTip.add(TextFormatting.GOLD + "" + TextFormatting.ITALIC + "Soil Pollution: " + TextFormatting.RED + '+' + Float.toString(soil));
 			}
 		}
-		
+
 		return currentTip;
 	}
 
 	public static void callbackRegister(IWailaRegistrar registrar)
 	{
-		registrar.registerBodyProvider(new EMWailaHandler(), BlockFilter.class);
-		registrar.registerBodyProvider(new EMWailaHandler(), BlockAnalyzer.class);
-		registrar.registerBodyProvider(new EMWailaHandler(), BlockAdvancedFilter.class);
+		registrar.registerBodyProvider(new EMWailaHandler(), TileEntity.class);
 	}
 }


### PR DESCRIPTION
Shows how much Pollution a TileEntity is producing. This includes both reductions in pollution and increases in pollution.

This is useful for large modpacks as it makes it easier for players to track down the causes of pollution.